### PR TITLE
Fix: Decouple orderbook refresh and onchain balance refresh

### DIFF
--- a/poly_market_maker/clob_api.py
+++ b/poly_market_maker/clob_api.py
@@ -77,14 +77,23 @@ class ClobApi:
             resp = self.client.create_and_post_limit_order(
                 LimitOrderArgs(price=price, size=size, side=side, token_id=self.token_id)
             )
+            order_id = None
             if resp and resp.get("success") and resp.get("orderID"):
-                return resp.get("orderID")
+                order_id = resp.get("orderID")
+                self.logger.info(f"Succesfully placed new order: Order[price={price},size={size},side={side}]!")
+                return order_id
+
+            err_msg = resp.get("errorMsg")
+            self.logger.info(f"Could not place new order! CLOB returned error: {err_msg}")
         except Exception as e:
-            self.logger.error(f"Error placing new order on the CLOB API: {e}")
+            self.logger.error(f"Request exception: failed placing new order: {e}")
         return None
 
     def cancel_order(self, order_id):
         self.logger.info(f"Cancelling order {order_id}...")
+        if order_id is None:
+            self.logger.debug("Invalid order_id")
+            return True
         try:
             resp = self.client.cancel(order_id)
             return resp == OK


### PR DESCRIPTION
<!-- Pull request template for CLOB projects. Modify as needed. -->
<!-- Delete any sub-sections not used rather than leaving them empty. -->

## Overview

<!-- Provide a brief (1-3 sentence) summary of the PR and it's purpose. May include plans if a [WIP]. -->
- RPC failures/rate limits sometimes cause the onchain balance refresh to fail. This function was tightly coupled with the orderbook refresh, so if the onchain balance failed, the keeper would effectively stop working
- This PR decouples the two functions, adds some extra logging and some protection

## Description

<!-- Describe in detail what changes you plan to make in this section and sub-sections. -->

## Testing instructions

<!-- If the PR changes how tests should be run, describe here. -->

## Types of changes

<!-- Check one of the boxes below, and add additional information as necessary. -->

- [ ] Refactor/enhancement <!-- Non-breaking (patch bump). -->
- [x] Bug fix/behavior correction <!-- Non-breaking (patch bump). -->
- [ ] New feature <!-- Non-breaking (minor bump), unless also specified as breaking. -->
- [ ] Breaking change <!-- Feature or bug fix that changes behavior and requires a major version bump. -->
- [ ] Other, additional <!-- Describe below/above. -->

## Notes

<!-- Include any additional comments, links, questions, or discussion items here. -->

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [ ] Prefix PR title with `[WIP]` if necessary (changes not yet made).
- [ ] Add tests to cover changes as needed.
- [ ] Update documentation/changelog as needed.
- [ ] Verify all tests run correctly in CI and pass.
- [x] Ready for review/merge.
