### PR TITLE
tweak: make logs directory automatically to avoid initial error.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,4 +11,6 @@ source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
 
+mkdir -p logs
+
 echo "Installation complete!"


### PR DESCRIPTION
Adds a /logs directory on installation to avoid initial error.

Note that git doesn't save empty dirs (https://archive.kernel.org/oldwiki/git.wiki.kernel.org/index.php/GitFaq.html#Can_I_add_empty_directories.3F), which may explain the origin of this error.