### PR TITLE
Fix no FilterParams in new clob version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ parsimonious==0.8.1
 pluggy==1.0.0
 protobuf==3.19.4
 py==1.11.0
-py-clob-client>=0.13.3
+py-clob-client==0.13.3
 py-order-utils>=0.0.21
 pycryptodome==3.14.1
 pyparsing==3.0.7


### PR DESCRIPTION
Fixes no FilterParams in new clob version by changing to version that contains that class

## Overview

on fresh install the 0.17 version of clob api doesn't have the FilterParams class
