### PR TITLE
feat: make installable on ARM by bumping lru-dict to 1.3.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,7 +8,10 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ idna==3.3
 iniconfig==1.1.1
 ipfshttpclient==0.8.0a2
 jsonschema==3.2.0
-lru-dict==1.1.7
+lru-dict==1.3.0
 multiaddr==0.0.9
 multidict==6.0.2
 netaddr==0.8.0


### PR DESCRIPTION
Resolves #75

## Overview

Bump lru-dict to version 1.3.0, from version 1.1.7 in requirements.txt

## Description

This is necessary to make `./install.sh` work on macs with ARM chips (i.e. all macs shipped since 2020)

See #75 for the error

## Testing instructions

<!-- If the PR changes how tests should be run, describe here. -->

## Types of changes

- [x] New feature

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [x] Add tests to cover changes as needed: added macos as OS to test on in CI
- [x] Verify all tests run correctly in CI and pass.
- [x] Ready for review/merge.
