### PR TITLE
ci: allow tests to be triggered by workflow dispatch

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ on:
     branches: main
   pull_request:
     branches: "*"
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
<!-- Pull request template for CLOB projects. Modify as needed. -->
<!-- Delete any sub-sections not used rather than leaving them empty. -->

## Overview

I couldn't run the tests for #75 without extra dummy commit in my fork because the tests don't come with workflow dispatch. It's a no brainer to allow workflow dispatch for the test action.

## Types of changes

- [x] CI

## Status

<!-- Check any boxes that are already complete upon creation of the PR, and update whenever necessary. -->
<!-- Make sure to check the "Ready for review" box when you are signing off on your changes for merge! -->

- [ ] Verify all tests run correctly in CI and pass.
- [x] Ready for review/merge.
