### PR TITLE
fix: guard debug log against None orders to prevent silent thread death

### DIFF
--- a/poly_market_maker/orderbook.py
+++ b/poly_market_maker/orderbook.py
@@ -384,12 +384,13 @@ class OrderBookManager:
 
                 self._report_order_book_updated()
 
-                self.logger.debug(
-                    f"Fetched the order book"
-                    f" (orders: {[order.id for order in orders]}, "
-                    f" buys: {len([order for order in orders if order.side == Side.BUY])}, "
-                    f" sells: {len([order for order in orders if order.side == Side.SELL])})"
-                )
+                if orders is not None:
+                    self.logger.debug(
+                        f"Fetched the order book"
+                        f" (orders: {[order.id for order in orders]}, "
+                        f" buys: {len([order for order in orders if order.side == Side.BUY])}, "
+                        f" sells: {len([order for order in orders if order.side == Side.SELL])})"
+                    )
             except ValueError as e:
                 self.logger.error(f"Failed to fetch the order book or balances ({e})!")
 


### PR DESCRIPTION
## Problem

The `_thread_refresh_order_book` thread dies permanently and silently when `_run_get_orders()` returns `None` (e.g. on an API timeout or 429).

`_run_get_orders()` is designed to return `None` on failure — the state update at line 377 correctly guards with `if orders is not None:`. However the debug log 10 lines later iterates `orders` unconditionally:

```python
self.logger.debug(
    f"Fetched the order book"
    f" (orders: {[order.id for order in orders]}, "   # ← TypeError if orders is None
    ...
)
```

This raises `TypeError: NoneType object is not iterable`. The surrounding `except` block only catches `ValueError`, so the `TypeError` propagates and kills the thread. No further logs are emitted, no restart occurs — the market maker silently stops refreshing its order book.

## Fix

Wrap the debug log inside the existing `if orders is not None:` guard, consistent with the state update directly above it.

```python
if orders is not None:
    self._state["orders"] = orders
    self.logger.debug(
        f"Fetched the order book"
        f" (orders: {[order.id for order in orders]}, "
        f" buys: {len([o for o in orders if o.side == Side.BUY])}, "
        f" sells: {len([o for o in orders if o.side == Side.SELL])})"
    )
```

Closes #87.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional around logging in the refresh loop; no change to order placement, cancellation, or state-update semantics.
> 
> **Overview**
> Fixes a bug where the background order-book refresh thread could **exit permanently** when `_run_get_orders()` returns `None` (timeouts, 429s, etc.).
> 
> State updates were already skipped when `orders` is `None`, but the post-refresh **debug log still iterated `orders`**, raising `TypeError`. That exception is **not** caught (only `ValueError` is), so the daemon thread stopped and the market maker **stopped refreshing** with little obvious signal.
> 
> The debug log is now emitted only inside **`if orders is not None:`**, matching the state-update guard above it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32522b68bebed677ff78c001d628770e9bd05b37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->