### PR TITLE
docs: note that proxy/deposit wallets are not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The keeper is an automated market maker for CLOB markets.
 Places and cancels orders to keep open orders near the midpoint price according to one of two strategies.
 
 ## Requirements
+> **Note:** This market maker trades directly with an EOA (Externally Owned Account) private key. Proxy wallet / deposit wallet accounts (those created via the Polymarket web UI, Magic.link, or Privy) are **not supported**. You must use a standard EOA private key. See [#79](https://github.com/Polymarket/poly-market-maker/issues/79) for context.
+
 
 - Python 3.10
 


### PR DESCRIPTION
## Problem

The README does not mention what wallet types are supported. Users who created their Polymarket account via the web UI (Magic.link / Privy deposit-wallet flow) repeatedly open issues when the market maker rejects their credentials or behaves unexpectedly — see #79, #28, #27, #86.

The market maker trades directly with an EOA private key. It has no proxy-wallet or deposit-wallet support — there is no `funderAddress` or `POLY_1271` flow. This is non-obvious to anyone who set up their Polymarket account via the modern web onboarding.

## Fix

Add a prominent note under the Requirements section so users know before they start setup.

Closes #79.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no impact on application logic, security, or deployment.
> 
> **Overview**
> Adds a **Requirements** callout stating the keeper only works with a standard **EOA private key**, and that Polymarket **proxy / deposit wallet** accounts (web UI, Magic.link, Privy) are **not supported**, with a link to issue #79 for background.
> 
> No code, config, or runtime behavior changes—documentation only to set expectations before setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e7861fda667b7787f6befcda1e375b6ab9bf87e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->